### PR TITLE
Fixing output format on invalid roles

### DIFF
--- a/gen/installer/bash.py
+++ b/gen/installer/bash.py
@@ -356,7 +356,7 @@ function check_all() {
     for role in "$ROLES"
     do
         if [ "$role" != "master" -a "$role" != "slave" -a "$role" != "slave_public" -a "$role" != "minuteman" ]; then
-            echo -e "${RED}FAIL Invalid role $role. Role must be one of {master,slave,slave_public}{NORMAL}"
+            echo -e "${RED}FAIL Invalid role $role. Role must be one of {master,slave,slave_public}${NORMAL}"
             (( OVERALL_RC += 1 ))
         fi
     done


### PR DESCRIPTION
If you supply an invalid role, all output after the error is then red, this fixes it so output is returned to normal after the single line is printed.
